### PR TITLE
Remove redundant variable

### DIFF
--- a/groups/stack/main.tf
+++ b/groups/stack/main.tf
@@ -179,7 +179,6 @@ module "ecs-services" {
   # bankrupt-officer-search-stack variables
   bankrupt_officer_search_web_release_version            = var.bankrupt_officer_search_web_release_version
   bankrupt_officer_search_web_application_port           = "10000"
-  bankrupt_officer_search_api_url                        = var.bankrupt_officer_search_api_url
   bankrupt_officer_search_web_oauth2_redirect_uri        = var.bankrupt_officer_search_web_oauth2_redirect_uri
   bankrupt_officer_search_web_oauth2_token_uri           = var.bankrupt_officer_search_web_oauth2_token_uri
   bankrupt_officer_search_web_cdn_host                   = var.bankrupt_officer_search_web_cdn_host

--- a/groups/stack/variables.tf
+++ b/groups/stack/variables.tf
@@ -180,10 +180,6 @@ variable "bankrupt_officer_search_web_release_version" {
   type        = string
   description = "The release version for the bankrupt-officer-search-web service."
 }
-variable "bankrupt_officer_search_api_url" {
-  type        = string
-  description = "The URL for the Bankrupt Officer Search API service."
-}
 variable "bankrupt_officer_search_web_oauth2_redirect_uri" {
   type = string
   description = "The uri to which to redirect after authorisation i.e. the CHS web url plus callback path \"/oauth2/user/callback\""


### PR DESCRIPTION
This variable should be deleted. This used to be “pay_api_url” from the payments stack which referenced the payments API, this stack doesn't need this.