### PR TITLE
Removed eric environment definition

### DIFF
--- a/groups/stack/main.tf
+++ b/groups/stack/main.tf
@@ -160,18 +160,6 @@ module "ecs-services" {
   cookie_domain             = var.cookie_domain
   cookie_name               = var.cookie_name
 
-  # eric specific configs
-  eric_version                   = var.eric_version
-  eric_cache_url                 = var.eric_cache_url
-  eric_cache_max_connections     = var.eric_cache_max_connections
-  eric_cache_max_idle            = var.eric_cache_max_idle
-  eric_cache_idle_timeout        = var.eric_cache_idle_timeout
-  eric_cache_ttl                 = var.eric_cache_ttl
-  eric_flush_interval            = var.eric_flush_interval
-  eric_graceful_shutdown_period  = var.eric_graceful_shutdown_period
-  eric_default_rate_limit        = var.eric_default_rate_limit
-  eric_default_rate_limit_window = var.eric_default_rate_limit_window
-
   # api configs
   internal_api_url                   = var.internal_api_url
   api_url                            = var.api_url

--- a/groups/stack/module-ecs-services/bados-web-task-definition.tmpl
+++ b/groups/stack/module-ecs-services/bados-web-task-definition.tmpl
@@ -1,49 +1,5 @@
 [
-    {
-        "environment": [
-            { "name": "PORT", "value": "${eric_port}" },
-            { "name": "ACCOUNT_API_URL", "value": "https://${account_subdomain_prefix}${external_top_level_domain}" },
-            { "name": "DEVELOPER_HUB_URL", "value": "https://developer${external_top_level_domain}" },
-            { "name": "CACHE_URL", "value": "${eric_cache_url}" },
-            { "name": "CACHE_MAX_CONNECTIONS", "value": "${eric_cache_max_connections}" },
-            { "name": "CACHE_MAX_IDLE", "value": "${eric_cache_max_idle}" },
-            { "name": "CACHE_IDLE_TIMEOUT", "value": "${eric_cache_idle_timeout}" },
-            { "name": "CACHE_TTL", "value": "${eric_cache_ttl}" },
-            { "name": "FLUSH_INTERVAL", "value": "${eric_flush_interval}" },
-            { "name": "GRACEFUL_SHUTDOWN_PERIOD", "value": "${eric_graceful_shutdown_period}" },
-            { "name": "DEFAULT_RATE_LIMIT", "value": "${eric_default_rate_limit}" },
-            { "name": "DEFAULT_RATE_WINDOW", "value": "${eric_default_rate_limit_window}" },
-            { "name": "PROXY_TARGET_URLS", "value": "http://${service_name}:${bados_web_proxy_port}" },
-            { "name": "MODE", "value": "web" },
-            { "name": "LOGLEVEL", "value": "${log_level}" }
-        ],
-        "name": "eric",
-        "image": "${docker_registry}/eric:${eric_version}",
-        "cpu": 1,
-        "memory": 512,
-        "portMappings": [{
-            "containerPort": ${eric_port},
-            "hostPort": 0,
-            "protocol": "tcp"
-        }],
-       "links": [
-         "${service_name}"
-       ],
-        "logConfiguration": {
-            "logDriver": "awslogs",
-            "options": {
-                "awslogs-create-group": "true",
-                "awslogs-region": "${aws_region}",
-                "awslogs-group": "/ecs/${name_prefix}/eric",
-                "awslogs-stream-prefix": "ecs"
-            }
-        },
-        "secrets": [
-            { "name": "API_KEY", "valueFrom": "${eric-api-key}" },
-            { "name": "AES256_KEY", "valueFrom": "${eric-aes256-key}" }
-        ],
-        "essential": true
-    },
+
     {
         "environment": [
             { "name": "PORT", "value": "${bados_web_proxy_port}" },


### PR DESCRIPTION
Bankrupt officer search API supports OAuth2 authentication only so therefore the ERIC configuartion is not required.

BI-11928